### PR TITLE
Support for multiple steps in the prompting process

### DIFF
--- a/bin/run-prompts.sh
+++ b/bin/run-prompts.sh
@@ -42,7 +42,6 @@ fi
 models=`sed -e's/ / --model /g' <<< ${_models[@]}`
 
 python $ROOT/src/prompt/build.py ${_extra[@]} \
-       --model $models \
        --user-prompts $_prompts/user \
        --system-prompts $_prompts/system \
        --documents $_documents \
@@ -53,5 +52,6 @@ python $ROOT/src/prompt/build.py ${_extra[@]} \
 	cat
     fi | \
 	python $ROOT/src/prompt/run.py \
+	       --model $models \
 	       --document-root $_documents \
 	       --prompt-root $_prompts

--- a/mylib/__init__.py
+++ b/mylib/__init__.py
@@ -1,2 +1,2 @@
 from ._logs import Logger
-from ._experiment import Experiment
+from ._experiment import Experiment, ExperimentResponse, ResponseJudgement

--- a/mylib/_experiment.py
+++ b/mylib/_experiment.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any
 from pathlib import Path
 from dataclasses import dataclass, asdict, field, fields
 
@@ -34,4 +35,5 @@ class ExperimentResponse:
 @dataclass(frozen=True)
 class ResponseJudgement:
     method: str
-    body: dict
+    score: float
+    support: Any

--- a/mylib/_experiment.py
+++ b/mylib/_experiment.py
@@ -1,9 +1,9 @@
+import time
 from pathlib import Path
-from dataclasses import dataclass, asdict, fields
+from dataclasses import dataclass, asdict, field, fields
 
-@dataclass
+@dataclass(frozen=True)
 class Experiment:
-    model: str
     system: Path
     user: Path
     docs: Path
@@ -22,3 +22,16 @@ class Experiment:
     @classmethod
     def stringify(cls, config):
         return ' '.join(str(config.get(x.name)) for x in fields(cls))
+
+@dataclass(frozen=True)
+class ExperimentResponse:
+    message: str
+    date: str = field(default_factory=lambda: time.strftime('%c'))
+
+    def __str__(self):
+        return self.message
+
+@dataclass(frozen=True)
+class ResponseJudgement:
+    method: str
+    body: dict

--- a/src/analysis/json-to-csv.py
+++ b/src/analysis/json-to-csv.py
@@ -24,6 +24,21 @@ def _(element: Union[str, int]):
 #
 #
 #
+class ScoreHandler:
+    def __init__(self, method):
+        self.method = method
+
+    def __call__(self, judgements):
+        (*_, score) = self.gather(gather)
+        return score
+
+    def gather(self, judgements):
+        for j in judgements:
+            if j['method'] == self.method:
+                yield j['score']
+#
+#
+#
 def parse(collection):
     for (k, v) in collection.items():
         try:
@@ -32,19 +47,25 @@ def parse(collection):
             continue
         yield (k, v)
 
-def func(incoming, outgoing, nchars):
+def func(incoming, outgoing, args):
+    handler = ScoreHandler(args.method)
+    prompts = (
+        'system',
+        'user',
+    )
+
     while True:
         result = incoming.get()
         # Logger.info(result)
 
         data = json.loads(result)
-        if nchars is not None:
-            for i in ('system', 'user'):
-                data[i] = data[i][:nchars]
+        if args.name_length is not None:
+            for i in prompts:
+                data[i] = data[i][:args.name_length]
             docs = Path(data['docs'])
-            docs = docs.parent.joinpath(docs.name[:nchars])
+            docs = docs.parent.joinpath(docs.name[:args.name_length])
             data['docs'] = str(docs)
-        score = data['judgement']['score']
+        score = handler(data['judgement'])
 
         outgoing.put(dict(parse(data), score=score))
 
@@ -53,6 +74,7 @@ def func(incoming, outgoing, nchars):
 #
 if __name__ == '__main__':
     arguments = ArgumentParser()
+    arguments.add_argument('--method')
     arguments.add_argument('--name-length', type=int)
     arguments.add_argument('--workers', type=int)
     args = arguments.parse_args()

--- a/src/evaluate/openai_/build.py
+++ b/src/evaluate/openai_/build.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 from dataclasses import dataclass, asdict
 from multiprocessing import Pool, Queue
 
-# from mylib import Logger
+from mylib import ExperimentResponse
 
 @dataclass
 class Message:

--- a/src/evaluate/openai_/build.py
+++ b/src/evaluate/openai_/build.py
@@ -33,17 +33,18 @@ def func(incoming, outgoing, args):
     references = ReferenceIterator(args.repetition)
 
     while True:
-        response = incoming.get()
+        sample = incoming.get()
 
-        pr = json.loads(response)
+        pr = json.loads(sample)
         gt = args.ground_truth.joinpath(pr['user'])
         if gt.exists():
-            response = pr['response'][args.response_key]
+            latest = pr['response'][args.response_index]
+            response = ExperimentResponse(**latest)
 
             for r in references(gt):
                 reference = r.data.read_text()
                 content = prompt.substitute(
-                    response=response,
+                    response=response.message,
                     reference=reference,
                     lower=args.low_score,
                     upper=args.high_score,
@@ -67,7 +68,7 @@ if __name__ == '__main__':
     arguments.add_argument('--repetition', type=int, default=1)
     arguments.add_argument('--low-score', type=int, default=1)
     arguments.add_argument('--high-score', type=int, default=5)
-    arguments.add_argument('--response-key', default='message')
+    arguments.add_argument('--response-index', type=int, default=-1)
     arguments.add_argument('--workers', type=int)
     args = arguments.parse_args()
 

--- a/src/evaluate/openai_/run.py
+++ b/src/evaluate/openai_/run.py
@@ -34,7 +34,8 @@ def func(incoming, outgoing, args):
                 .message
                 .parsed
                 .model_dump())
-        judgement = ResponseJudgement(method, body)
+        score = body.pop('score')
+        judgement = ResponseJudgement(method, score, body)
 
         record = config.setdefault('judgement', [])
         record.append(asdict(judgement))

--- a/src/evaluate/openai_/run.py
+++ b/src/evaluate/openai_/run.py
@@ -1,12 +1,13 @@
 import sys
 import json
 from argparse import ArgumentParser
+from dataclasses import asdict
 from multiprocessing import Pool, Queue
 
 from openai import OpenAI
 from pydantic import BaseModel
 
-from mylib import Logger, Experiment
+from mylib import Logger, Experiment, ResponseJudgement
 
 class SimilarityEvaluation(BaseModel):
     overlap: str
@@ -16,6 +17,7 @@ class SimilarityEvaluation(BaseModel):
 
 def func(incoming, outgoing, args):
     client = OpenAI()
+    method = f'{args.model}:custom'
 
     while True:
         sample = incoming.get()
@@ -27,11 +29,15 @@ def func(incoming, outgoing, args):
             messages=config['evaluation'],
             response_format=SimilarityEvaluation,
         )
-        config['judgement'] = (response
-                               .choices[0]
-                               .message
-                               .parsed
-                               .model_dump())
+        body = (response
+                .choices[0]
+                .message
+                .parsed
+                .model_dump())
+        judgement = ResponseJudgement(method, body)
+
+        record = config.setdefault('judgement', [])
+        record.append(asdict(judgement))
 
         outgoing.put(config)
 

--- a/src/prompt/build.py
+++ b/src/prompt/build.py
@@ -12,7 +12,6 @@ def documents(path):
 
 if __name__ == '__main__':
     arguments = ArgumentParser()
-    arguments.add_argument('--model', action='append')
     arguments.add_argument('--user-prompts', type=Path)
     arguments.add_argument('--system-prompts', type=Path)
     arguments.add_argument('--documents', type=Path)
@@ -21,7 +20,6 @@ if __name__ == '__main__':
     args = arguments.parse_args()
 
     conditions = (
-        args.model,
         args.system_prompts.iterdir(),
         args.user_prompts.iterdir(),
         documents(args.documents),

--- a/src/prompt/run.py
+++ b/src/prompt/run.py
@@ -233,7 +233,7 @@ class OpenAIResources:
                     resource = Resource(assistant, vector_store)
                     self.resources[key] = resource
 
-                yield Job(resource, m, config)
+                yield Job(resource, model, config)
 
 #
 #

--- a/src/prompt/run.py
+++ b/src/prompt/run.py
@@ -5,7 +5,7 @@ import operator as op
 import collections as cl
 from pathlib import Path
 from argparse import ArgumentParser
-from dataclasses import dataclass, astuple
+from dataclasses import dataclass, astuple, asdict
 from multiprocessing import Pool, Queue
 
 from openai import OpenAI, NotFoundError


### PR DESCRIPTION
The current prompt pipeline assumes a single model interaction, and a single evaluation step. These changes support multiple interaction steps and multiple evaluation frameworks. This is realised through changes to the final output JSONs:

* Responses and judgements are lists of dictionaries. Scripts that add to the JSON are respectful of potential values within a list that may already be there
* The model name/type lives with the response, instead of at the root

In the case of responses, it is assumed that the order in which a response dictionary is added is the same order in which response generator appeared in the pipeline.